### PR TITLE
Added try/catch block to .yarnclean write file operation

### DIFF
--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -120,7 +120,9 @@ export async function run(
   args: Array<string>,
 ): Promise<void> {
   reporter.step(1, 2, reporter.lang('cleanCreatingFile', CLEAN_FILENAME));
-  await fs.writeFile(path.join(config.cwd, CLEAN_FILENAME), '\n', {flag: 'wx'});
+  try {
+      await fs.writeFile(path.join(config.cwd, CLEAN_FILENAME), '\n', {flag: 'wx'});
+  } catch (e) {}
 
   reporter.step(2, 2, reporter.lang('cleaning'));
   const {removedFiles, removedSize} = await clean(config, reporter);


### PR DESCRIPTION
Added try catch block to handle error „EEXIST: file already exists“.
